### PR TITLE
Enabled compiler optimisations on linux

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,14 @@ set_target_properties(RayTraceEngine PROPERTIES VERSION ${PROJECT_VERSION} SOVER
 
 # For MacOS Framework
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    message(STATUS "MacOS detected, PUBLIC_HEADER has been set.")
     set_target_properties(RayTraceEngine PROPERTIES PUBLIC_HEADER "include/RayTraceEngine/RayTraceCore.h;include/RayTraceEngine/RayEngine.h;include/RayTraceEngine/MissShader.h;include/RayTraceEngine/HitShader.h;include/RayTraceEngine/OcclusionShader.h;include/RayTraceEngine/PierceShader.h;include/RayTraceEngine/RayGeneratorShader.h;include/RayTraceEngine/Object.h;include/RayTraceEngine/Pipeline.h;include/RayTraceEngine/Shader.h;include/RayTraceEngine/BasicStructures.h;include/RayTraceEngine/TriangleMeshObject.h")
+endif()
+
+# Compiler optimisations
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    message(STATUS "Linux detected, enabled compiler optimisations..")
+    set(CMAKE_CXX_FLAGS "-pthread -O2 -march=native")
 endif()
 
 configure_file(RayTraceEngine.pc.in RayTraceEngine.pc @ONLY)


### PR DESCRIPTION
-O2 was chosen over -O3 because they give the same performance on my system and -O3 can be detrimental to performance on some systems